### PR TITLE
Remove official 3D model library submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "official-libraries/kicad-footprints"]
 	path = official-libraries/kicad-footprints
 	url = ../kicad-footprints
-[submodule "official-libraries/kicad-packages3D"]
-	path = official-libraries/kicad-packages3D
-	url = ../kicad-packages3D
 
 # utilities
 [submodule "utilities/kicad-library-utils"]


### PR DESCRIPTION
Resolves #19 (Remove official 3D model library submodule).

The set of symbol libraries and footprint libraries available for use by
a project are managed using tables. This is not done for 3D model
libraries. Instead, footprints contain the path to the associated 3D
model relative to a KiCad environment variable (`KISYS3DMOD` for the
official libraries). The set of standard KiCad environment variables
cannot support a project structure where libraries are managed in a
single Git repository that is then used as a submodule by projects.

Using a smudge filter (as suggested by
https://bugs.launchpad.net/kicad/+bug/1840458/comments/4) and/or placing
the 3D models in their own repository could be used as potential
workarounds for this sometime in the future.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
